### PR TITLE
Display total number of lines in the CSS string

### DIFF
--- a/assets/aliases.json
+++ b/assets/aliases.json
@@ -4,6 +4,7 @@
   "stylesheets": "Style Sheets",
   "styleElements": "Style Elements",
   "size": "Size",
+  "totalLines": "Total Lines",
   "dataUriSize": "Data URI Size",
   "ratioOfDataUriSize": "Ratio of Data URI Size",
   "gzippedSize": "Gzipped Size",

--- a/assets/default.json
+++ b/assets/default.json
@@ -4,6 +4,7 @@
   "stylesheets": true,
   "styleElements": true,
   "size": true,
+  "totalLines": true,
   "dataUriSize": true,
   "ratioOfDataUriSize": true,
   "gzippedSize": false,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -74,6 +74,7 @@ Parser.prototype.parse = function (callback) {
   var parsedData = {
     cssString: '',
     cssSize: 0,
+    totalLines: 0,
     styleElements: 0,
     mediaQueries: 0,
     cssFiles: 0,
@@ -202,6 +203,8 @@ Parser.prototype.parse = function (callback) {
     // join all css string
     parsedData.cssString = that.styles.join('');
     parsedData.cssSize = Buffer.byteLength(parsedData.cssString, 'utf8');
+    // count total lines in css file
+    parsedData.totalLines = parsedData.cssString.split('\n').length;
 
     // parse css string
     var rawRules = [];

--- a/lib/stylestats.js
+++ b/lib/stylestats.js
@@ -119,6 +119,9 @@ StyleStats.prototype.parse = function (callback) {
     if (that.options.mediaQueries) {
       stats.mediaQueries = data.mediaQueries;
     }
+    if (that.options.totalLines) {
+      stats.totalLines = data.totalLines;
+    }
     callback(null, stats);
   });
 };


### PR DESCRIPTION
Added a total lines metric, based on splitting the parsedData.cssString by \n.