### PR TITLE
Added unique font-size count to help identify sizes that are used less frequently

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -158,11 +158,14 @@ Analyzer.prototype.analyzeDeclarations = function () {
     dataUriSize: '',
     importantKeywords: 0,
     floatProperties: 0,
-    uniqueFontSizes: {},
+    uniqueFontSizes: [],
     uniqueFontFamilies: [],
     uniqueColors: [],
     properties: {}
   };
+
+  // hash table to record unique font-size counts
+  var uniqueFontSizeCounts = {};
 
   // analyze declarations
   this.declarations.forEach(function (declaration) {
@@ -190,10 +193,11 @@ Analyzer.prototype.analyzeDeclarations = function () {
     // if it contains font-size
     if (declaration.property.indexOf('font-size') > -1) {
       var size = declaration.value.replace(/\!important/, '').trim();
-      if (result.uniqueFontSizes[size]) {
-        result.uniqueFontSizes[size] += 1;
+      result.uniqueFontSizes.push(size);
+      if (uniqueFontSizeCounts[size]) {
+        uniqueFontSizeCounts[size] += 1;
       } else {
-        result.uniqueFontSizes[size] = 1;
+        uniqueFontSizeCounts[size] = 1;
       }
     }
 
@@ -218,15 +222,14 @@ Analyzer.prototype.analyzeDeclarations = function () {
   // Sort `font-family` property.
   result.uniqueFontFamilies = _.sortBy(_.uniq(result.uniqueFontFamilies));
 
-  var tempArray = [];
-  _.each(result.uniqueFontSizes, function (key, value) {
-    tempArray.push(value + ': (' + key + ')');
-  });
-  result.uniqueFontSizes = tempArray;
-
   // Sort `font-size` property.
   result.uniqueFontSizes = _.sortBy(_.uniq(result.uniqueFontSizes).slice(), function (item) {
-   return item.split(':')[0].replace(/[^0-9\.]/g, '') - 0;
+   return item.replace(/[^0-9\.]/g, '') - 0;
+  });
+
+  // Add count to each unique font-size
+  _.each(result.uniqueFontSizes, function (value, key) {
+    result.uniqueFontSizes[key] = value + ': ' + uniqueFontSizeCounts[value];
   });
 
   // Sort `color` property.

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -158,7 +158,7 @@ Analyzer.prototype.analyzeDeclarations = function () {
     dataUriSize: '',
     importantKeywords: 0,
     floatProperties: 0,
-    uniqueFontSizes: [],
+    uniqueFontSizes: {},
     uniqueFontFamilies: [],
     uniqueColors: [],
     properties: {}
@@ -189,7 +189,12 @@ Analyzer.prototype.analyzeDeclarations = function () {
 
     // if it contains font-size
     if (declaration.property.indexOf('font-size') > -1) {
-      result.uniqueFontSizes.push(declaration.value.replace(/\!important/, '').trim());
+      var size = declaration.value.replace(/\!important/, '').trim();
+      if (result.uniqueFontSizes[size]) {
+        result.uniqueFontSizes[size] += 1;
+      } else {
+        result.uniqueFontSizes[size] = 1;
+      }
     }
 
     // if it contains colors
@@ -213,9 +218,17 @@ Analyzer.prototype.analyzeDeclarations = function () {
   // Sort `font-family` property.
   result.uniqueFontFamilies = _.sortBy(_.uniq(result.uniqueFontFamilies));
 
+  var tempArray = [];
+  for (var index in result.uniqueFontSizes) {
+    if (result.uniqueFontSizes.hasOwnProperty(index)) {
+      tempArray.push(index + ': (' + result.uniqueFontSizes[index] + ')');
+    }
+  }
+  result.uniqueFontSizes = tempArray;
+
   // Sort `font-size` property.
   result.uniqueFontSizes = _.sortBy(_.uniq(result.uniqueFontSizes).slice(), function (item) {
-    return item.replace(/[^0-9\.]/g, '') - 0;
+   return item.split(':')[0].replace(/[^0-9\.]/g, '') - 0;
   });
 
   // Sort `color` property.
@@ -264,7 +277,6 @@ Analyzer.prototype.analyzeDeclarations = function () {
  *   {Number} totalUniqueFontSizes,
  *   {String} uniqueFontSizes,
  *   {Number} totalUniqueFontFamilies,
- *   {String} uniqueFontSizes,
  *   {Number} totalUniqueColors,
  *   {String} uniqueColors,
  *   {Number} totalUniqueFontFamilies

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -219,11 +219,9 @@ Analyzer.prototype.analyzeDeclarations = function () {
   result.uniqueFontFamilies = _.sortBy(_.uniq(result.uniqueFontFamilies));
 
   var tempArray = [];
-  for (var index in result.uniqueFontSizes) {
-    if (result.uniqueFontSizes.hasOwnProperty(index)) {
-      tempArray.push(index + ': (' + result.uniqueFontSizes[index] + ')');
-    }
-  }
+  _.each(result.uniqueFontSizes, function (key, value) {
+    tempArray.push(value + ': (' + key + ')');
+  });
   result.uniqueFontSizes = tempArray;
 
   // Sort `font-size` property.

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -224,7 +224,7 @@ Analyzer.prototype.analyzeDeclarations = function () {
 
   // Sort `font-size` property.
   result.uniqueFontSizes = _.sortBy(_.uniq(result.uniqueFontSizes).slice(), function (item) {
-   return item.replace(/[^0-9\.]/g, '') - 0;
+    return item.replace(/[^0-9\.]/g, '') - 0;
   });
 
   // Add count to each unique font-size


### PR DESCRIPTION
When auditing CSS, I find this useful for catching one-off font sizes. @t32k, let me know you’re interested in this feature.