### PR TITLE
Extend parse error information

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,6 +9,8 @@ var cssParse = require('css-parse');
 
 var util = require('./util');
 
+var currentFile;
+
 /**
  * Get promised request
  * @param {Object} options
@@ -209,7 +211,7 @@ Parser.prototype.parse = function (callback) {
     try {
       rawRules = cssParse(parsedData.cssString).stylesheet.rules;
     } catch (error) {
-      throw new Error('CSS parse error.');
+      throw new Error('CSS parse error in file ' + currentFile + '. Detailed error:' + error);
     }
 
     // check number of rules


### PR DESCRIPTION
Add more information when an error occurred:

- Filename where the parse error occurs.
- Detailed error.