### PR TITLE
added missing promise package

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,6 +5,7 @@ var request = require('request');
 var cheerio = require('cheerio');
 var cssParse = require('css-parse');
 var util = require('./util');
+var Promise = require('promise');
 
 /**
  * Get promised request

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "moment": "^2.11.2",
     "numeral": "^1.5.3",
     "object-assign": "^4.0.1",
+    "promise": "^7.1.1",
     "request": "^2.69.0",
     "valid-url": "^1.0.9"
   },


### PR DESCRIPTION
When I called the `.parse()` function the callback was never triggered, after further investigating the problem:

In parser.js:94:
`Promise.all(requestPromises).then(function onFulfilled(results) {..`

requestPromises is an empty array, as I only tried with css local file paths. But this should still trigger `.then()`. 

But with my setup this was not working, after overriding the default promise package, it works perfect.
