### PR TITLE
Use native Object.assign()

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,6 @@
 
 var fs = require('fs');
 var chalk = require('chalk');
-var assign = require('object-assign');
 var program = require('commander');
 
 var StyleStats = require('../lib/stylestats');
@@ -50,7 +49,7 @@ if (program.mobile) {
   config.requestOptions.headers['User-Agent'] = MOBILE_UA;
 }
 if (program.number) {
-  assign(config, numberConfig);
+  Object.assign(config, numberConfig);
 }
 if (program.config && util.isFile(program.config)) {
   var configString = fs.readFileSync(program.config, {
@@ -64,7 +63,7 @@ if (program.config && util.isFile(program.config)) {
 } else if (util.isObject(program.config)) {
   userConfig = config;
 }
-assign(config, userConfig);
+Object.assign(config, userConfig);
 
 
 // Parse

--- a/lib/stylestats.js
+++ b/lib/stylestats.js
@@ -11,7 +11,6 @@
 var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
-var assign = require('object-assign');
 var validUrl = require('valid-url');
 
 var util = require('./util');
@@ -74,7 +73,7 @@ function StyleStats(args, config) {
     customOptions = config;
   }
 
-  this.options = assign({}, defaultOptions, customOptions);
+  this.options = Object.assign({}, defaultOptions, customOptions);
   this.parser = new Parser(this.urls, this.files, this.styles, this.options);
 }
 
@@ -113,7 +112,7 @@ StyleStats.prototype.parse = function (callback) {
     if (that.options.styleElements) {
       stats.styleElements = data.styleElements;
     }
-    assign(stats, analyzedData);
+    Object.assign(stats, analyzedData);
     if (that.options.mediaQueries) {
       stats.mediaQueries = data.mediaQueries;
     }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "mocha": "^2.4.5",
     "moment": "^2.11.2",
     "numeral": "^1.5.3",
-    "object-assign": "^4.0.1",
     "request": "^2.69.0",
     "valid-url": "^1.0.9"
   },


### PR DESCRIPTION
## Why

This package target Node.js version is [>= 4.x](https://github.com/t32k/stylestats/blob/master/package.json#L32).

`Object.assign()` build-in for Node.js ver 4 or later.

- [sindresorhus/object\-assign: ES2015 Object\.assign\(\) ponyfill](https://github.com/sindresorhus/object-assign#use-the-built-in)
- [Node\.js ES2015/ES6 support](http://node.green/#Object-static-methods)

## Summary

- Remove `object-assign` package
- Use native `Object.assign()`